### PR TITLE
Feature/ltk 11429 modification of imgtool utility for certificate based code signing

### DIFF
--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -61,6 +61,7 @@ primary slot and adds a header and trailer that the bootloader is expecting:
     Options:
       -k, --key filename
       --public-key-format [hash|full]
+	  --cert                        Certificate file path with tag field value
       --align [1|2|4|8]             [required]
       -v, --version TEXT            [required]
       -s, --security-counter TEXT   Specify the value of security counter. Use
@@ -133,3 +134,7 @@ public key is incorporated into the bootloader). When the `full` option is used
 instead, the TLV area will contain the whole public key and thus the bootloader
 can be independent from the key(s). For more information on the additional
 requirements of this option, see the [design](design.md) document.
+
+The --cert argument can be used to provide the certificate file path.
+Specify the option multiple time to add multiple certificates. Tag field can 
+have the same value. TLV will be created in the form : Tag|Length|Value.

--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -139,6 +139,6 @@ requirements of this option, see the [design](design.md) document.
 The --cert argument can be used to provide the certificate file path.
 Specify the option 2 times to add intermediate and product certificates.
 Certificate need to be pass in sequence i.e 1st Intermediate and 2nd Product
-certificate. Root Certificate not required and should not be pass as argument.
+certificate. Root Certificate is not required to pass as argument. It should be part of bootloader as a trusted ca.
 Certificate TLV will hold the "X509" i.e 0x03 as tag value.
 

--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -61,7 +61,8 @@ primary slot and adds a header and trailer that the bootloader is expecting:
     Options:
       -k, --key filename
       --public-key-format [hash|full]
-	  --cert                        Certificate file path with tag field value
+      --cert                        Specify intermediate and product certificate 
+                                    file path.
       --align [1|2|4|8]             [required]
       -v, --version TEXT            [required]
       -s, --security-counter TEXT   Specify the value of security counter. Use
@@ -136,5 +137,8 @@ can be independent from the key(s). For more information on the additional
 requirements of this option, see the [design](design.md) document.
 
 The --cert argument can be used to provide the certificate file path.
-Specify the option multiple time to add multiple certificates. Tag field can 
-have the same value. TLV will be created in the form : Tag|Length|Value.
+Specify the option 2 times to add intermediate and product certificates.
+Certificate need to be pass in sequence i.e 1st Intermediate and 2nd Product
+certificate. Root Certificate not required and should not be pass as argument.
+Certificate TLV will hold the "X509" i.e 0x03 as tag value.
+

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -412,9 +412,9 @@ class Image():
 
         # add certificates value as TLV
         if certificates is not None:
-            # Certificates dictionary contain Tag name and Tag value field inside value part. 
+            # Certificates dictionary contain Tag value field inside value part. 
             for index, value in certificates.items():
-                tlv.add(value[0], value[1])
+                tlv.add('X509', value)
 
         if key is not None:
             # keyhash is not required in certificates based approach

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -299,11 +299,11 @@ class BasedIntParamType(click.ParamType):
               required=True)
 @click.option('--cert', required=False, nargs=1, default=[], multiple=True,
               metavar='[filename]',
-              help='cert argument will be used to provide the certificate file'
-                   'path. Specify the option 2 times to add Intermediate and'
-                   'Product certificates. Certificate need to be pass in sequence'
+              help='cert argument will be used to provide the certificate file '
+                   'path. Specify the option 2 times to add Intermediate and '
+                   'Product certificates. Certificate need to be pass in sequence '
                    'i.e 1st Intermediate and 2nd Product certificate. Root '
-                   'Certificate not required and should not be pass as argument.'
+                   'Certificate not required and should not be pass as argument. '
                    'Certificate TLV will hold the "X509" i.e 0x03 as tag value.')
 @click.option('--public-key-format', type=click.Choice(['hash', 'full']),
               default='hash', help='In what format to add the public key to '

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -303,7 +303,7 @@ class BasedIntParamType(click.ParamType):
                    'path. Specify the option 2 times to add Intermediate and '
                    'Product certificates. Certificate need to be pass in sequence '
                    'i.e 1st Intermediate and 2nd Product certificate. Root '
-                   'Certificate not required and should not be pass as argument. '
+                   'Certificate not required to pass as argument. It should be part of '
                    'Certificate TLV will hold the "X509" i.e 0x03 as tag value.')
 @click.option('--public-key-format', type=click.Choice(['hash', 'full']),
               default='hash', help='In what format to add the public key to '

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -304,7 +304,7 @@ class BasedIntParamType(click.ParamType):
                    'Product certificates. Certificate need to be pass in sequence '
                    'i.e 1st Intermediate and 2nd Product certificate. Root '
                    'Certificate not required to pass as argument. It should be part of '
-                   'Certificate TLV will hold the "X509" i.e 0x03 as tag value.')
+                   'bootloader. Certificate TLV will hold the "X509" i.e 0x03 as tag value.')
 @click.option('--public-key-format', type=click.Choice(['hash', 'full']),
               default='hash', help='In what format to add the public key to '
               'the image manifest: full key or hash of the key.')

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -299,7 +299,7 @@ class BasedIntParamType(click.ParamType):
               required=True)
 @click.option('--cert', required=False, nargs=1, default=[], multiple=True,
               metavar='[filename]',
-              help='cert argument will be used to provide the certificate file '
+              help='This argument will be used to provide the certificate file '
                    'path. Specify the option 2 times to add Intermediate and '
                    'Product certificates. Certificate need to be pass in sequence '
                    'i.e 1st Intermediate and 2nd Product certificate. Root '

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -75,7 +75,7 @@ def load_cert(filename):
         with open(filename, 'rb') as file:
             value = file.read()
     except FileNotFoundError:
-        msg = " The file " + filename + " does not exist".
+        msg = " The file " + filename + " does not exist"
         print( msg )
     return value
 

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -76,7 +76,7 @@ def load_cert(filename):
             value = file.read()
     except FileNotFoundError:
         msg = " The file " + filename + " does not exist"
-        print( msg )
+        print(msg)
     return value
 
 
@@ -297,9 +297,14 @@ class BasedIntParamType(click.ParamType):
 @click.option('-v', '--version', callback=validate_version,  required=True)
 @click.option('--align', type=click.Choice(['1', '2', '4', '8']),
               required=True)
-@click.option('--cert', required=False, nargs=2, default=[], multiple=True,
-              metavar='[tag] [filename]',
-              help='Certificate TLV')
+@click.option('--cert', required=False, nargs=1, default=[], multiple=True,
+              metavar='[filename]',
+              help='cert argument will be used to provide the certificate file'
+                   'path. Specify the option 2 times to add Intermediate and'
+                   'Product certificates. Certificate need to be pass in sequence'
+                   'i.e 1st Intermediate and 2nd Product certificate. Root '
+                   'Certificate not required and should not be pass as argument.'
+                   'Certificate TLV will hold the "X509" i.e 0x03 as tag value.')
 @click.option('--public-key-format', type=click.Choice(['hash', 'full']),
               default='hash', help='In what format to add the public key to '
               'the image manifest: full key or hash of the key.')
@@ -360,8 +365,8 @@ def sign(key, public_key_format, cert, align, version, pad_sig, header_size,
     # Get list of certificates from the command-line
     index = 0
     certificates = {}
-    for cert_value in cert:
-        certificates[index] = (int(cert_value[0], 0), load_cert(cert_value[1]))
+    for filepath in cert:
+        certificates[index] = load_cert(filepath)
         index += 1
 
     # Create signed image

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -69,6 +69,17 @@ keygens = {
 }
 
 
+def load_cert(filename):
+    # open certificate file and read data in binary format 
+    try:
+        with open(filename, 'rb') as file:
+            value = file.read()
+    except FileNotFoundError:
+        msg = " The file " + filename + " does not exist".
+        print( msg )
+    return value
+
+
 def load_key(keyfile):
     # TODO: better handling of invalid pass-phrase
     key = keys.load(keyfile)
@@ -286,6 +297,9 @@ class BasedIntParamType(click.ParamType):
 @click.option('-v', '--version', callback=validate_version,  required=True)
 @click.option('--align', type=click.Choice(['1', '2', '4', '8']),
               required=True)
+@click.option('--cert', required=False, nargs=2, default=[], multiple=True,
+              metavar='[tag] [filename]',
+              help='Certificate TLV')
 @click.option('--public-key-format', type=click.Choice(['hash', 'full']),
               default='hash', help='In what format to add the public key to '
               'the image manifest: full key or hash of the key.')
@@ -293,7 +307,7 @@ class BasedIntParamType(click.ParamType):
 @click.command(help='''Create a signed or unsigned image\n
                INFILE and OUTFILE are parsed as Intel HEX if the params have
                .hex extension, otherwise binary format is used''')
-def sign(key, public_key_format, align, version, pad_sig, header_size,
+def sign(key, public_key_format, cert, align, version, pad_sig, header_size,
          pad_header, slot_size, pad, confirm, max_sectors, overwrite_only,
          endian, encrypt, infile, outfile, dependencies, load_addr, hex_addr,
          erased_val, save_enctlv, security_counter, boot_record, custom_tlv,
@@ -343,7 +357,15 @@ def sign(key, public_key_format, align, version, pad_sig, header_size,
         else:
             custom_tlvs[tag] = value.encode('utf-8')
 
-    img.create(key, public_key_format, enckey, dependencies, boot_record,
+    # Get list of certificates from the command-line
+    index = 0
+    certificates = {}
+    for cert_value in cert:
+        certificates[index] = (int(cert_value[0], 0), load_cert(cert_value[1]))
+        index += 1
+
+    # Create signed image
+    img.create(key, public_key_format, enckey, certificates, dependencies, boot_record,
                custom_tlvs)
     img.save(outfile, hex_addr)
 


### PR DESCRIPTION
Added the support for --cert command in imgtool utility for adding the certificate TLV in signed code pack. 
Signed code pack can be generated using der formatted or pem formatted certificates. 